### PR TITLE
🔧 Patch for Local Storage Cache Check Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Quickblaze Files
+.vscode/
 .stashed/
 .gitattributes
 .dccache

--- a/Modules/functions.php
+++ b/Modules/functions.php
@@ -144,7 +144,7 @@ function initialiseSystem()
                         die();
                     } else {
                         $cache = json_decode(file_get_contents("./local-storage/.cache"), true);
-                        if ($cache["DO-NOT-TOUCH:database_installation_status"] == "false") {
+                        if ($cache["DO-NOT-TOUCH:database_installation_status"] == "false" || !isset($cache["DO-NOT-TOUCH:database_installation_status"])) {
                             $tableCreateSQL = "CREATE TABLE IF NOT EXISTS `quickblaze_records` (`record_id` int(11) NOT NULL, `encrypted_contents` longtext NOT NULL, `encryption_token` varchar(128) NOT NULL, `source_ip` varchar(100) NOT NULL, `record_date` timestamp(5) NOT NULL DEFAULT current_timestamp(5)) ENGINE=InnoDB DEFAULT CHARSET=utf8;";
                             $addPrimaryKeySQL = "ALTER TABLE `quickblaze_records` ADD PRIMARY KEY (`record_id`);";
                             if ($conn->query($tableCreateSQL)) {


### PR DESCRIPTION
Fix for app first run.

After first run app create a empty file /local-storage/.cache, 
in line 147 if condition $cache["DO-NOT-TOUCH:database_installation_status"] == "false" incorrect b/c file is empty.

Correct condition or if statement is ($cache["DO-NOT-TOUCH:database_installation_status"] == "false" || !isset($cache["DO-NOT-TOUCH:database_installation_status"])).